### PR TITLE
Add support for LLVM 18.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ llvm14-0 = ["llvm-sys-140"]
 llvm15-0 = ["llvm-sys-150"]
 llvm16-0 = ["llvm-sys-160"]
 llvm17-0 = ["llvm-sys-170"]
-llvm18-0 = ["llvm-sys-180"]
+llvm18-1 = ["llvm-sys-181"]
 
 # Don't link against LLVM libraries. This is useful if another dependency is
 # installing LLVM. See llvm-sys for more details. We can't enable a single
@@ -50,7 +50,7 @@ llvm14-0-no-llvm-linking = ["llvm14-0", "llvm-sys-140/no-llvm-linking"]
 llvm15-0-no-llvm-linking = ["llvm15-0", "llvm-sys-150/no-llvm-linking"]
 llvm16-0-no-llvm-linking = ["llvm16-0", "llvm-sys-160/no-llvm-linking"]
 llvm17-0-no-llvm-linking = ["llvm17-0", "llvm-sys-170/no-llvm-linking"]
-llvm18-0-no-llvm-linking = ["llvm18-0", "llvm-sys-180/no-llvm-linking"]
+llvm18-1-no-llvm-linking = ["llvm18-1", "llvm-sys-181/no-llvm-linking"]
 
 # Linking preference.
 # If none of these are enabled, it defaults to force static linking.
@@ -62,7 +62,7 @@ llvm14-0-force-dynamic = ["llvm14-0", "llvm-sys-140/force-dynamic"]
 llvm15-0-force-dynamic = ["llvm15-0", "llvm-sys-150/force-dynamic"]
 llvm16-0-force-dynamic = ["llvm16-0", "llvm-sys-160/force-dynamic"]
 llvm17-0-force-dynamic = ["llvm17-0", "llvm-sys-170/force-dynamic"]
-llvm18-0-force-dynamic = ["llvm18-0", "llvm-sys-180/force-dynamic"]
+llvm18-1-force-dynamic = ["llvm18-1", "llvm-sys-181/force-dynamic"]
 
 # Prefer dynamic linking against LLVM libraries. See llvm-sys for more details
 llvm12-0-prefer-dynamic = ["llvm12-0", "llvm-sys-120/prefer-dynamic"]
@@ -71,7 +71,7 @@ llvm14-0-prefer-dynamic = ["llvm14-0", "llvm-sys-140/prefer-dynamic"]
 llvm15-0-prefer-dynamic = ["llvm15-0", "llvm-sys-150/prefer-dynamic"]
 llvm16-0-prefer-dynamic = ["llvm16-0", "llvm-sys-160/prefer-dynamic"]
 llvm17-0-prefer-dynamic = ["llvm17-0", "llvm-sys-170/prefer-dynamic"]
-llvm18-0-prefer-dynamic = ["llvm18-0", "llvm-sys-180/prefer-dynamic"]
+llvm18-1-prefer-dynamic = ["llvm18-1", "llvm-sys-181/prefer-dynamic"]
 
 # Force static linking against LLVM libraries. See llvm-sys for more details
 llvm12-0-force-static = ["llvm12-0", "llvm-sys-120/force-static"]
@@ -80,7 +80,7 @@ llvm14-0-force-static = ["llvm14-0", "llvm-sys-140/force-static"]
 llvm15-0-force-static = ["llvm15-0", "llvm-sys-150/force-static"]
 llvm16-0-force-static = ["llvm16-0", "llvm-sys-160/force-static"]
 llvm17-0-force-static = ["llvm17-0", "llvm-sys-170/force-static"]
-llvm18-0-force-static = ["llvm18-0", "llvm-sys-180/force-static"]
+llvm18-1-force-static = ["llvm18-1", "llvm-sys-181/force-static"]
 
 # Prefer static linking against LLVM libraries. See llvm-sys for more details
 llvm12-0-prefer-static = ["llvm12-0", "llvm-sys-120/prefer-static"]
@@ -89,7 +89,7 @@ llvm14-0-prefer-static = ["llvm14-0", "llvm-sys-140/prefer-static"]
 llvm15-0-prefer-static = ["llvm15-0", "llvm-sys-150/prefer-static"]
 llvm16-0-prefer-static = ["llvm16-0", "llvm-sys-160/prefer-static"]
 llvm17-0-prefer-static = ["llvm17-0", "llvm-sys-170/prefer-static"]
-llvm18-0-prefer-static = ["llvm18-0", "llvm-sys-180/prefer-static"]
+llvm18-1-prefer-static = ["llvm18-1", "llvm-sys-181/prefer-static"]
 
 # Don't force linking to libffi on non-windows platforms. Without this feature
 # inkwell always links to libffi on non-windows platforms.
@@ -151,7 +151,7 @@ llvm-sys-140 = { package = "llvm-sys", version = "140.0.2", optional = true }
 llvm-sys-150 = { package = "llvm-sys", version = "150.0.3", optional = true }
 llvm-sys-160 = { package = "llvm-sys", version = "160.1.0", optional = true }
 llvm-sys-170 = { package = "llvm-sys", version = "170.0.1", optional = true }
-llvm-sys-180 = { package = "llvm-sys", version = "180.0.0", optional = true }
+llvm-sys-181 = { package = "llvm-sys", version = "181.1.0", optional = true }
 
 either = "1.5"
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You'll need to point your Cargo.toml to use a single LLVM version feature flag c
 
 ```toml
 [dependencies]
-inkwell = { version = "0.4.0", features = ["llvm18-0"] }
+inkwell = { version = "0.4.0", features = ["llvm18-1"] }
 ```
 
 Supported versions:

--- a/internal_macros/src/cfg.rs
+++ b/internal_macros/src/cfg.rs
@@ -10,7 +10,7 @@ use syn::{Lit, RangeLimits};
 // This array should match the LLVM features in the top level Cargo manifest
 const FEATURE_VERSIONS: &[&str] = &[
     "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0", "llvm9-0", "llvm10-0", "llvm11-0", "llvm12-0", "llvm13-0",
-    "llvm14-0", "llvm15-0", "llvm16-0", "llvm17-0", "llvm18-0",
+    "llvm14-0", "llvm15-0", "llvm16-0", "llvm17-0", "llvm18-1",
 ];
 
 pub struct VersionRange {

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -288,9 +288,9 @@ impl<'ctx> BasicBlock<'ctx> {
     ///
     /// let void_type = context.void_type();
     /// let i32_type = context.i32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let i32_ptr_type = context.ptr_type(AddressSpace::default());
     ///
     /// let fn_type = void_type.fn_type(&[i32_ptr_type.into()], false);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -456,9 +456,9 @@ impl<'ctx> Builder<'ctx> {
     ///     };
     ///
     ///     // type of an exception in C++
-    ///     #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    ///     #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     ///     let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::default());
-    ///     #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    ///     #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     ///     let i32_ptr_ty = context.ptr_type(AddressSpace::default());
     ///     let i32_type = context.i32_type();
     ///     let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
@@ -708,9 +708,9 @@ impl<'ctx> Builder<'ctx> {
     /// let builder = context.create_builder();
     ///
     /// // type of an exception in C++
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let i8_ptr_type = context.i8_type().ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let i8_ptr_type = context.ptr_type(AddressSpace::default());
     /// let i32_type = context.i32_type();
     /// let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
@@ -740,9 +740,9 @@ impl<'ctx> Builder<'ctx> {
     /// let builder = context.create_builder();
     ///
     /// // type of an exception in C++
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let i8_ptr_type = context.i8_type().ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let i8_ptr_type = context.ptr_type(AddressSpace::default());
     /// let i32_type = context.i32_type();
     /// let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
@@ -775,9 +775,9 @@ impl<'ctx> Builder<'ctx> {
     /// let builder = context.create_builder();
     ///
     /// // type of an exception in C++
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let i8_ptr_type = context.i8_type().ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let i8_ptr_type = context.ptr_type(AddressSpace::default());
     /// let i32_type = context.i32_type();
     /// let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
@@ -813,9 +813,9 @@ impl<'ctx> Builder<'ctx> {
     /// let builder = context.create_builder();
     ///
     /// // type of an exception in C++
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let i8_ptr_type = context.i8_type().ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let i8_ptr_type = context.ptr_type(AddressSpace::default());
     /// let i32_type = context.i32_type();
     /// let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
@@ -935,9 +935,9 @@ impl<'ctx> Builder<'ctx> {
     ///     };
     ///
     ///     // type of an exception in C++
-    ///     #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    ///     #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     ///     let i8_ptr_type = context.i8_type().ptr_type(AddressSpace::default());
-    ///     #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    ///     #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     ///     let i8_ptr_type = context.ptr_type(AddressSpace::default());
     ///     let i32_type = context.i32_type();
     ///     let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
@@ -1087,9 +1087,9 @@ impl<'ctx> Builder<'ctx> {
     /// let module = context.create_module("struct_gep");
     /// let void_type = context.void_type();
     /// let i32_ty = context.i32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let i32_ptr_ty = i32_ty.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let i32_ptr_ty = context.ptr_type(AddressSpace::default());
     /// let field_types = &[i32_ty.into(), i32_ty.into()];
     /// let struct_ty = context.struct_type(field_types, false);
@@ -1153,9 +1153,9 @@ impl<'ctx> Builder<'ctx> {
     /// let module = context.create_module("struct_gep");
     /// let void_type = context.void_type();
     /// let i32_ty = context.i32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let i32_ptr_ty = i32_ty.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let i32_ptr_ty = context.ptr_type(AddressSpace::default());
     /// let field_types = &[i32_ty.into(), i32_ty.into()];
     /// let struct_ty = context.struct_type(field_types, false);
@@ -1227,9 +1227,9 @@ impl<'ctx> Builder<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let i32_type = context.i32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let i32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[i32_ptr_type.into(), i32_ptr_type.into()], false);
     /// let fn_value = module.add_function("ret", fn_type, None);
@@ -1278,9 +1278,9 @@ impl<'ctx> Builder<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let i32_type = context.i32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let i32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[i32_ptr_type.into(), i32_ptr_type.into()], false);
     /// let fn_value = module.add_function("ret", fn_type, None);
@@ -1347,9 +1347,9 @@ impl<'ctx> Builder<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let i32_type = context.i32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let i32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let i32_seven = i32_type.const_int(7, false);
     /// let fn_type = void_type.fn_type(&[i32_ptr_type.into()], false);
@@ -1387,9 +1387,9 @@ impl<'ctx> Builder<'ctx> {
     /// let module = context.create_module("ret");
     /// let builder = context.create_builder();
     /// let i32_type = context.i32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let i32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let fn_type = i32_type.fn_type(&[i32_ptr_type.into()], false);
     /// let fn_value = module.add_function("ret", fn_type, None);
@@ -1427,9 +1427,9 @@ impl<'ctx> Builder<'ctx> {
     /// let module = context.create_module("ret");
     /// let builder = context.create_builder();
     /// let i32_type = context.i32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let i32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let fn_type = i32_type.fn_type(&[i32_ptr_type.into()], false);
     /// let fn_value = module.add_function("ret", fn_type, None);
@@ -2777,7 +2777,7 @@ impl<'ctx> Builder<'ctx> {
     ///     feature = "llvm14-0"
     /// ))]
     /// let array = builder.build_load(array_alloca, "array_load").unwrap().into_array_value();
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let array = builder.build_load(i32_type, array_alloca, "array_load").unwrap().into_array_value();
     ///
     /// let const_int1 = i32_type.const_int(2, false);
@@ -2860,7 +2860,7 @@ impl<'ctx> Builder<'ctx> {
     ///     feature = "llvm14-0"
     /// ))]
     /// let array = builder.build_load(array_alloca, "array_load").unwrap().into_array_value();
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let array = builder.build_load(i32_type, array_alloca, "array_load").unwrap().into_array_value();
     ///
     /// let const_int1 = i32_type.const_int(2, false);
@@ -3265,9 +3265,9 @@ impl<'ctx> Builder<'ctx> {
     /// let void_type = context.void_type();
     /// let i32_type = context.i32_type();
     /// let i32_seven = i32_type.const_int(7, false);
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let i32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[i32_ptr_type.into()], false);
     /// let fn_value = module.add_function("rmw", fn_type, None);
@@ -3302,7 +3302,7 @@ impl<'ctx> Builder<'ctx> {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         )))]
         if ptr.get_type().get_element_type() != value.get_type().into() {
             return Err(BuilderError::PointeeTypeMismatch(
@@ -3344,9 +3344,9 @@ impl<'ctx> Builder<'ctx> {
     /// let module = context.create_module("cmpxchg");
     /// let void_type = context.void_type();
     /// let i32_type = context.i32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let i32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[i32_ptr_type.into()], false);
     /// let fn_value = module.add_function("", fn_type, None);
@@ -3388,7 +3388,7 @@ impl<'ctx> Builder<'ctx> {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         )))]
         if ptr.get_type().get_element_type().as_basic_type_enum() != cmp.get_type() {
             return Err(BuilderError::PointeeTypeMismatch(

--- a/src/context.rs
+++ b/src/context.rs
@@ -579,7 +579,7 @@ impl Context {
     ///     builder.build_call(callable_value, params, "exit").unwrap();
     /// }
     ///
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// builder.build_indirect_call(asm_fn, asm, params, "exit").unwrap();
     ///
     /// builder.build_return(None).unwrap();
@@ -1447,7 +1447,7 @@ impl<'ctx> ContextRef<'ctx> {
     ///     builder.build_call(callable_value, params, "exit").unwrap();
     /// }
     ///
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// builder.build_indirect_call(asm_fn, asm, params, "exit").unwrap();
     ///
     /// builder.build_return(None).unwrap();

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -195,7 +195,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         sysroot: &str,
         #[cfg(any(
@@ -206,7 +206,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         sdk: &str,
     ) -> (Self, DICompileUnit<'ctx>) {
@@ -245,7 +245,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
                 feature = "llvm15-0",
                 feature = "llvm16-0",
                 feature = "llvm17-0",
-                feature = "llvm18-0"
+                feature = "llvm18-1"
             ))]
             sysroot,
             #[cfg(any(
@@ -256,7 +256,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
                 feature = "llvm15-0",
                 feature = "llvm16-0",
                 feature = "llvm17-0",
-                feature = "llvm18-0"
+                feature = "llvm18-1"
             ))]
             sdk,
         );
@@ -303,7 +303,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         sysroot: &str,
         #[cfg(any(
@@ -314,7 +314,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         sdk: &str,
     ) -> DICompileUnit<'ctx> {
@@ -356,7 +356,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
                 feature = "llvm15-0",
                 feature = "llvm16-0",
                 feature = "llvm17-0",
-                feature = "llvm18-0"
+                feature = "llvm18-1"
             ))]
             {
                 LLVMDIBuilderCreateCompileUnit(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,8 @@ pub extern crate llvm_sys_150 as llvm_sys;
 pub extern crate llvm_sys_160 as llvm_sys;
 #[cfg(feature = "llvm17-0")]
 pub extern crate llvm_sys_170 as llvm_sys;
-#[cfg(feature = "llvm18-0")]
-pub extern crate llvm_sys_180 as llvm_sys;
+#[cfg(feature = "llvm18-1")]
+pub extern crate llvm_sys_181 as llvm_sys;
 #[cfg(feature = "llvm4-0")]
 pub extern crate llvm_sys_40 as llvm_sys;
 #[cfg(feature = "llvm5-0")]
@@ -130,7 +130,7 @@ assert_unique_used_features! {
     "llvm15-0",
     "llvm16-0",
     "llvm17-0",
-    "llvm18-0"
+    "llvm18-1"
 }
 
 /// Defines the address space in which a global will be inserted.

--- a/src/module.rs
+++ b/src/module.rs
@@ -1433,7 +1433,7 @@ impl<'ctx> Module<'ctx> {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         sysroot: &str,
         #[cfg(any(
@@ -1444,7 +1444,7 @@ impl<'ctx> Module<'ctx> {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         sdk: &str,
     ) -> (DebugInfoBuilder<'ctx>, DICompileUnit<'ctx>) {
@@ -1471,7 +1471,7 @@ impl<'ctx> Module<'ctx> {
                 feature = "llvm15-0",
                 feature = "llvm16-0",
                 feature = "llvm17-0",
-                feature = "llvm18-0"
+                feature = "llvm18-1"
             ))]
             sysroot,
             #[cfg(any(
@@ -1482,7 +1482,7 @@ impl<'ctx> Module<'ctx> {
                 feature = "llvm15-0",
                 feature = "llvm16-0",
                 feature = "llvm17-0",
-                feature = "llvm18-0"
+                feature = "llvm18-1"
             ))]
             sdk,
         )

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -14,7 +14,7 @@ use llvm_sys::target_machine::{
     LLVMTargetHasAsmBackend, LLVMTargetHasJIT, LLVMTargetHasTargetMachine, LLVMTargetMachineEmitToFile,
     LLVMTargetMachineEmitToMemoryBuffer, LLVMTargetMachineRef, LLVMTargetRef,
 };
-#[llvm_versions(18..)]
+#[llvm_versions(18.1..)]
 use llvm_sys::target_machine::{
     LLVMCreateTargetMachineOptions, LLVMCreateTargetMachineWithOptions, LLVMDisposeTargetMachineOptions,
     LLVMTargetMachineOptionsRef, LLVMTargetMachineOptionsSetABI, LLVMTargetMachineOptionsSetCPU,
@@ -960,7 +960,7 @@ impl Target {
     /// assert_eq!(target_machine.get_cpu().to_str(), Ok("x86-64"));
     /// assert_eq!(target_machine.get_feature_string().to_str(), Ok("+avx2"));
     /// ```
-    #[llvm_versions(18..)]
+    #[llvm_versions(18.1..)]
     pub fn create_target_machine_from_options(
         &self,
         triple: &TargetTriple,
@@ -1422,11 +1422,11 @@ impl Drop for TargetData {
 ///
 /// The option structure exposes an additional setting (i.e., the target ABI)
 /// and provides default values for unspecified settings.
-#[llvm_versions(18..)]
+#[llvm_versions(18.1..)]
 #[derive(Default, Debug)]
 pub struct TargetMachineOptions(Option<LLVMTargetMachineOptionsRef>);
 
-#[llvm_versions(18..)]
+#[llvm_versions(18.1..)]
 impl TargetMachineOptions {
     pub fn new() -> Self {
         Default::default()
@@ -1491,7 +1491,7 @@ impl TargetMachineOptions {
     }
 }
 
-#[llvm_versions(18..)]
+#[llvm_versions(18.1..)]
 impl Drop for TargetMachineOptions {
     fn drop(&mut self) {
         if let Some(inner) = self.0 {

--- a/src/types/array_type.rs
+++ b/src/types/array_type.rs
@@ -97,7 +97,7 @@ impl<'ctx> ArrayType<'ctx> {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ),
         deprecated(
             note = "Starting from version 15.0, LLVM doesn't differentiate between pointer types. Use Context::ptr_type instead."

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -224,7 +224,7 @@ impl<'ctx> AnyTypeEnum<'ctx> {
                 feature = "llvm15-0",
                 feature = "llvm16-0",
                 feature = "llvm17-0",
-                feature = "llvm18-0"
+                feature = "llvm18-1"
             ))]
             LLVMTypeKind::LLVMBFloatTypeKind => AnyTypeEnum::FloatType(FloatType::new(type_)),
             LLVMTypeKind::LLVMLabelTypeKind => panic!("FIXME: Unsupported type: Label"),
@@ -242,7 +242,7 @@ impl<'ctx> AnyTypeEnum<'ctx> {
                 feature = "llvm15-0",
                 feature = "llvm16-0",
                 feature = "llvm17-0",
-                feature = "llvm18-0"
+                feature = "llvm18-1"
             ))]
             LLVMTypeKind::LLVMScalableVectorTypeKind => AnyTypeEnum::VectorType(VectorType::new(type_)),
             // FIXME: should inkwell support metadata as AnyType?
@@ -255,11 +255,11 @@ impl<'ctx> AnyTypeEnum<'ctx> {
                 feature = "llvm15-0",
                 feature = "llvm16-0",
                 feature = "llvm17-0",
-                feature = "llvm18-0"
+                feature = "llvm18-1"
             ))]
             LLVMTypeKind::LLVMX86_AMXTypeKind => panic!("FIXME: Unsupported type: AMX"),
             LLVMTypeKind::LLVMTokenTypeKind => panic!("FIXME: Unsupported type: Token"),
-            #[cfg(any(feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+            #[cfg(any(feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
             LLVMTypeKind::LLVMTargetExtTypeKind => panic!("FIXME: Unsupported type: TargetExt"),
         }
     }
@@ -414,7 +414,7 @@ impl<'ctx> BasicTypeEnum<'ctx> {
                 feature = "llvm15-0",
                 feature = "llvm16-0",
                 feature = "llvm17-0",
-                feature = "llvm18-0"
+                feature = "llvm18-1"
             ))]
             LLVMTypeKind::LLVMBFloatTypeKind => BasicTypeEnum::FloatType(FloatType::new(type_)),
             LLVMTypeKind::LLVMIntegerTypeKind => BasicTypeEnum::IntType(IntType::new(type_)),
@@ -430,7 +430,7 @@ impl<'ctx> BasicTypeEnum<'ctx> {
                 feature = "llvm15-0",
                 feature = "llvm16-0",
                 feature = "llvm17-0",
-                feature = "llvm18-0"
+                feature = "llvm18-1"
             ))]
             LLVMTypeKind::LLVMScalableVectorTypeKind => BasicTypeEnum::VectorType(VectorType::new(type_)),
             LLVMTypeKind::LLVMMetadataTypeKind => panic!("Unsupported basic type: Metadata"),
@@ -444,14 +444,14 @@ impl<'ctx> BasicTypeEnum<'ctx> {
                 feature = "llvm15-0",
                 feature = "llvm16-0",
                 feature = "llvm17-0",
-                feature = "llvm18-0"
+                feature = "llvm18-1"
             ))]
             LLVMTypeKind::LLVMX86_AMXTypeKind => unreachable!("Unsupported basic type: AMX"),
             LLVMTypeKind::LLVMLabelTypeKind => unreachable!("Unsupported basic type: Label"),
             LLVMTypeKind::LLVMVoidTypeKind => unreachable!("Unsupported basic type: VoidType"),
             LLVMTypeKind::LLVMFunctionTypeKind => unreachable!("Unsupported basic type: FunctionType"),
             LLVMTypeKind::LLVMTokenTypeKind => unreachable!("Unsupported basic type: Token"),
-            #[cfg(any(feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+            #[cfg(any(feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
             LLVMTypeKind::LLVMTargetExtTypeKind => unreachable!("Unsupported basic type: TargetExt"),
         }
     }

--- a/src/types/float_type.rs
+++ b/src/types/float_type.rs
@@ -235,7 +235,7 @@ impl<'ctx> FloatType<'ctx> {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ),
         deprecated(
             note = "Starting from version 15.0, LLVM doesn't differentiate between pointer types. Use Context::ptr_type instead."

--- a/src/types/fn_type.rs
+++ b/src/types/fn_type.rs
@@ -65,7 +65,7 @@ impl<'ctx> FunctionType<'ctx> {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ),
         deprecated(
             note = "Starting from version 15.0, LLVM doesn't differentiate between pointer types. Use Context::ptr_type instead."

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -322,7 +322,7 @@ impl<'ctx> IntType<'ctx> {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ),
         deprecated(
             note = "Starting from version 15.0, LLVM doesn't differentiate between pointer types. Use Context::ptr_type instead."

--- a/src/types/ptr_type.rs
+++ b/src/types/ptr_type.rs
@@ -44,9 +44,9 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let f32_ptr_type_size = f32_ptr_type.size_of();
     /// ```
@@ -64,9 +64,9 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let f32_ptr_type_alignment = f32_ptr_type.get_alignment();
     /// ```
@@ -84,9 +84,9 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let f32_ptr_ptr_type = f32_ptr_type.ptr_type(AddressSpace::default());
     ///
@@ -110,7 +110,7 @@ impl<'ctx> PointerType<'ctx> {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ),
         deprecated(
             note = "Starting from version 15.0, LLVM doesn't differentiate between pointer types. Use Context::ptr_type instead."
@@ -130,9 +130,9 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     ///
     /// assert_eq!(f32_ptr_type.get_context(), context);
@@ -152,9 +152,9 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let fn_type = f32_ptr_type.fn_type(&[], false);
     /// ```
@@ -172,9 +172,9 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let f32_ptr_array_type = f32_ptr_type.array_type(3);
     ///
@@ -195,9 +195,9 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     ///
     /// assert_eq!(f32_ptr_type.get_address_space(), AddressSpace::default());
@@ -224,9 +224,9 @@ impl<'ctx> PointerType<'ctx> {
     /// // Local Context
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let f32_ptr_null = f32_ptr_type.const_null();
     ///
@@ -249,9 +249,9 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let f32_ptr_zero = f32_ptr_type.const_zero();
     /// ```
@@ -268,9 +268,9 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let f32_ptr_undef = f32_ptr_type.get_undef();
     ///
@@ -290,9 +290,9 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let f32_ptr_undef = f32_ptr_type.get_poison();
     ///
@@ -313,9 +313,9 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let f32_ptr_vec_type = f32_ptr_type.vec_type(3);
     ///
@@ -337,9 +337,9 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     ///
     /// assert_eq!(f32_ptr_type.get_element_type().into_float_type(), f32_type);
@@ -358,9 +358,9 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let f32_ptr_val = f32_ptr_type.const_null();
     /// let f32_ptr_array = f32_ptr_type.const_array(&[f32_ptr_val, f32_ptr_val]);

--- a/src/types/struct_type.rs
+++ b/src/types/struct_type.rs
@@ -221,7 +221,7 @@ impl<'ctx> StructType<'ctx> {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ),
         deprecated(
             note = "Starting from version 15.0, LLVM doesn't differentiate between pointer types. Use Context::ptr_type instead."

--- a/src/types/traits.rs
+++ b/src/types/traits.rs
@@ -131,7 +131,7 @@ pub unsafe trait BasicType<'ctx>: AnyType<'ctx> {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ),
         deprecated(
             note = "Starting from version 15.0, LLVM doesn't differentiate between pointer types. Use Context::ptr_type instead."

--- a/src/types/vec_type.rs
+++ b/src/types/vec_type.rs
@@ -220,7 +220,7 @@ impl<'ctx> VectorType<'ctx> {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ),
         deprecated(
             note = "Starting from version 15.0, LLVM doesn't differentiate between pointer types. Use Context::ptr_type instead."

--- a/src/values/basic_value_use.rs
+++ b/src/values/basic_value_use.rs
@@ -40,9 +40,9 @@ impl<'ctx> BasicValueUse<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[f32_ptr_type.into()], false);
     ///
@@ -104,9 +104,9 @@ impl<'ctx> BasicValueUse<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[f32_ptr_type.into()], false);
     ///
@@ -143,9 +143,9 @@ impl<'ctx> BasicValueUse<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[f32_ptr_type.into()], false);
     ///

--- a/src/values/call_site_value.rs
+++ b/src/values/call_site_value.rs
@@ -5,7 +5,7 @@ use llvm_sys::core::{
     LLVMGetInstructionCallConv, LLVMGetTypeKind, LLVMIsTailCall, LLVMSetInstrParamAlignment,
     LLVMSetInstructionCallConv, LLVMSetTailCall, LLVMTypeOf,
 };
-#[llvm_versions(18..)]
+#[llvm_versions(18.1..)]
 use llvm_sys::core::{LLVMGetTailCallKind, LLVMSetTailCallKind};
 use llvm_sys::prelude::LLVMValueRef;
 use llvm_sys::LLVMTypeKind;
@@ -104,7 +104,7 @@ impl<'ctx> CallSiteValue<'ctx> {
     ///
     /// assert_eq!(call_site.get_tail_call_kind(), LLVMTailCallKindNone);
     /// ```
-    #[llvm_versions(18..)]
+    #[llvm_versions(18.1..)]
     pub fn get_tail_call_kind(self) -> super::LLVMTailCallKind {
         unsafe { LLVMGetTailCallKind(self.as_value_ref()) }
     }
@@ -131,7 +131,7 @@ impl<'ctx> CallSiteValue<'ctx> {
     /// call_site.set_tail_call_kind(LLVMTailCallKindTail);
     /// assert_eq!(call_site.get_tail_call_kind(), LLVMTailCallKindTail);
     /// ```
-    #[llvm_versions(18..)]
+    #[llvm_versions(18.1..)]
     pub fn set_tail_call_kind(self, kind: super::LLVMTailCallKind) {
         unsafe { LLVMSetTailCallKind(self.as_value_ref(), kind) };
     }

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -260,7 +260,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// Returns the tail call kind on call instructions.
     ///
     /// Other instructions return `None`.
-    #[llvm_versions(18..)]
+    #[llvm_versions(18.1..)]
     pub fn get_tail_call_kind(self) -> Option<super::LLVMTailCallKind> {
         if self.get_opcode() == InstructionOpcode::Call {
             unsafe { llvm_sys::core::LLVMGetTailCallKind(self.as_value_ref()) }.into()
@@ -272,7 +272,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// Check whether this instructions supports [fast math flags][0].
     ///
     /// [0]: https://llvm.org/docs/LangRef.html#fast-math-flags
-    #[llvm_versions(18..)]
+    #[llvm_versions(18.1..)]
     pub fn can_use_fast_math_flags(self) -> bool {
         unsafe { llvm_sys::core::LLVMCanValueUseFastMathFlags(self.as_value_ref()) == 1 }
     }
@@ -282,7 +282,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// Calling this on unsupported instructions is safe and returns `None`.
     ///
     /// [0]: https://llvm.org/docs/LangRef.html#fast-math-flags
-    #[llvm_versions(18..)]
+    #[llvm_versions(18.1..)]
     pub fn get_fast_math_flags(self) -> Option<u32> {
         self.can_use_fast_math_flags()
             .then(|| unsafe { llvm_sys::core::LLVMGetFastMathFlags(self.as_value_ref()) } as u32)
@@ -293,7 +293,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// Calling this on unsupported instructions is safe and results in a no-op.
     ///
     /// [0]: https://llvm.org/docs/LangRef.html#fast-math-flags
-    #[llvm_versions(18..)]
+    #[llvm_versions(18.1..)]
     pub fn set_fast_math_flags(self, flags: u32) {
         if self.can_use_fast_math_flags() {
             unsafe { llvm_sys::core::LLVMSetFastMathFlags(self.as_value_ref(), flags) };
@@ -303,7 +303,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// Check if a `zext` instruction has the non-negative flag set.
     ///
     /// Calling this function on other instructions is safe and returns `None`.
-    #[llvm_versions(18..)]
+    #[llvm_versions(18.1..)]
     pub fn get_non_negative_flag(self) -> Option<bool> {
         (self.get_opcode() == InstructionOpcode::ZExt)
             .then(|| unsafe { llvm_sys::core::LLVMGetNNeg(self.as_value_ref()) == 1 })
@@ -312,7 +312,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// Set the non-negative flag on `zext` instructions.
     ///
     /// Calling this function on other instructions is safe and results in a no-op.
-    #[llvm_versions(18..)]
+    #[llvm_versions(18.1..)]
     pub fn set_non_negative_flag(self, flag: bool) {
         if self.get_opcode() == InstructionOpcode::ZExt {
             unsafe { llvm_sys::core::LLVMSetNNeg(self.as_value_ref(), flag as i32) };
@@ -322,7 +322,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// Checks if an `or` instruction has the `disjoint` flag set.
     ///
     /// Calling this function on other instructions is safe and returns `None`.
-    #[llvm_versions(18..)]
+    #[llvm_versions(18.1..)]
     pub fn get_disjoint_flag(self) -> Option<bool> {
         (self.get_opcode() == InstructionOpcode::Or)
             .then(|| unsafe { llvm_sys::core::LLVMGetIsDisjoint(self.as_value_ref()) == 1 })
@@ -331,7 +331,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// Set the `disjoint` flag on `or` instructions.
     ///
     /// Calling this function on other instructions is safe and results in a no-op.
-    #[llvm_versions(18..)]
+    #[llvm_versions(18.1..)]
     pub fn set_disjoint_flag(self, flag: bool) {
         if self.get_opcode() == InstructionOpcode::Or {
             unsafe { llvm_sys::core::LLVMSetIsDisjoint(self.as_value_ref(), flag as i32) };
@@ -475,9 +475,9 @@ impl<'ctx> InstructionValue<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[f32_ptr_type.into()], false);
     ///
@@ -538,9 +538,9 @@ impl<'ctx> InstructionValue<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[f32_ptr_type.into()], false);
     ///
@@ -642,9 +642,9 @@ impl<'ctx> InstructionValue<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[f32_ptr_type.into()], false);
     ///
@@ -688,9 +688,9 @@ impl<'ctx> InstructionValue<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[f32_ptr_type.into()], false);
     ///
@@ -755,9 +755,9 @@ impl<'ctx> InstructionValue<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let f32_type = context.f32_type();
-    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[f32_ptr_type.into()], false);
     ///

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -38,7 +38,7 @@ pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = if cfg!(feature = "llvm4-0") {
     36
 } else if cfg!(any(feature = "llvm16-0", feature = "llvm17-0")) {
     39
-} else if cfg!(feature = "llvm18-0") {
+} else if cfg!(feature = "llvm18-1") {
     40
 } else {
     panic!("Unhandled LLVM version")

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -24,7 +24,7 @@ mod vec_value;
     feature = "llvm15-0",
     feature = "llvm16-0",
     feature = "llvm17-0",
-    feature = "llvm18-0"
+    feature = "llvm18-1"
 )))]
 mod callable_value;
 
@@ -32,7 +32,7 @@ mod callable_value;
     feature = "llvm15-0",
     feature = "llvm16-0",
     feature = "llvm17-0",
-    feature = "llvm18-0"
+    feature = "llvm18-1"
 )))]
 pub use crate::values::callable_value::CallableValue;
 
@@ -59,7 +59,7 @@ pub use crate::values::traits::AsValueRef;
 pub use crate::values::traits::{AggregateValue, AnyValue, BasicValue, FloatMathValue, IntMathValue, PointerMathValue};
 pub use crate::values::vec_value::VectorValue;
 
-#[llvm_versions(18..)]
+#[llvm_versions(18.1..)]
 pub use llvm_sys::LLVMTailCallKind;
 
 use llvm_sys::core::{

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -15,7 +15,7 @@ mod test_instruction_values;
 mod test_intrinsics;
 mod test_module;
 mod test_object_file;
-#[cfg(not(any(feature = "llvm17-0", feature = "llvm18-0")))]
+#[cfg(not(any(feature = "llvm17-0", feature = "llvm18-1")))]
 mod test_passes;
 mod test_targets;
 mod test_tari_example;

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -51,14 +51,14 @@ fn test_build_call() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let fn_ptr_type = fn_ptr.get_type();
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let fn_ptr_type = context.ptr_type(AddressSpace::default());
 
@@ -86,7 +86,7 @@ fn test_build_call() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let load = builder
         .build_load(fn_ptr_type, alloca, "load")
@@ -115,7 +115,7 @@ fn test_build_call() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     builder.build_indirect_call(fn_type2, load, &[], "call").unwrap();
     builder.build_return(None).unwrap();
@@ -183,14 +183,14 @@ fn test_build_invoke_cleanup_resume() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         )))]
         let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::default());
         #[cfg(any(
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         let i8_ptr_type = context.ptr_type(AddressSpace::default());
         let i32_type = context.i32_type();
@@ -267,14 +267,14 @@ fn test_build_invoke_catch_all() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         )))]
         let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::default());
         #[cfg(any(
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         let i8_ptr_type = context.ptr_type(AddressSpace::default());
         let i32_type = context.i32_type();
@@ -355,14 +355,14 @@ fn landing_pad_filter() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         )))]
         let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::default());
         #[cfg(any(
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         let i8_ptr_type = context.ptr_type(AddressSpace::default());
         let i32_type = context.i32_type();
@@ -413,14 +413,14 @@ fn test_null_checked_ptr_ops() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let i8_ptr_type = context.ptr_type(AddressSpace::default());
     let i64_type = context.i64_type();
@@ -472,7 +472,7 @@ fn test_null_checked_ptr_ops() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let index1 = builder.build_load(i8_ptr_type, new_ptr, "deref").unwrap();
 
@@ -531,7 +531,7 @@ fn test_null_checked_ptr_ops() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let index1 = builder.build_load(i8_ptr_type, new_ptr, "deref").unwrap();
 
@@ -1020,14 +1020,14 @@ fn test_vector_pointer_ops() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let i8_ptr_vec_type = context.i8_type().ptr_type(AddressSpace::default()).vec_type(4);
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let i8_ptr_vec_type = context.ptr_type(AddressSpace::default()).vec_type(4);
     let bool_vec_type = context.bool_type().vec_type(4);
@@ -1085,7 +1085,7 @@ fn test_insert_value() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let array = builder
         .build_load(array_type, array_alloca, "array_load")
@@ -1144,7 +1144,7 @@ fn test_insert_value() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let struct_value = builder
         .build_load(struct_type, struct_alloca, "struct_load")
@@ -1290,14 +1290,14 @@ fn run_memcpy_on<'ctx>(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let fn_type = i32_type.ptr_type(AddressSpace::default()).fn_type(&[], false);
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let fn_type = context.ptr_type(AddressSpace::default()).fn_type(&[], false);
     let fn_value = module.add_function("test_fn", fn_type, None);
@@ -1331,7 +1331,7 @@ fn run_memcpy_on<'ctx>(
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         let elem_ptr = unsafe {
             builder
@@ -1366,7 +1366,7 @@ fn run_memcpy_on<'ctx>(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let dest_ptr = unsafe {
         builder
@@ -1422,14 +1422,14 @@ fn run_memmove_on<'ctx>(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let fn_type = i32_type.ptr_type(AddressSpace::default()).fn_type(&[], false);
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let fn_type = context.ptr_type(AddressSpace::default()).fn_type(&[], false);
     let fn_value = module.add_function("test_fn", fn_type, None);
@@ -1463,7 +1463,7 @@ fn run_memmove_on<'ctx>(
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         let elem_ptr = unsafe {
             builder
@@ -1498,7 +1498,7 @@ fn run_memmove_on<'ctx>(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let dest_ptr = unsafe {
         builder
@@ -1555,14 +1555,14 @@ fn run_memset_on<'ctx>(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let fn_type = i32_type.ptr_type(AddressSpace::default()).fn_type(&[], false);
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let fn_type = context.ptr_type(AddressSpace::default()).fn_type(&[], false);
     let fn_value = module.add_function("test_fn", fn_type, None);
@@ -1602,7 +1602,7 @@ fn run_memset_on<'ctx>(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let part_2 = unsafe {
         builder
@@ -1658,28 +1658,28 @@ fn test_bit_cast() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let i32_ptr_type = context.ptr_type(AddressSpace::default());
     #[cfg(not(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let i64_ptr_type = i64_type.ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let i64_ptr_type = context.ptr_type(AddressSpace::default());
     let i32_vec_type = i32_type.vec_type(2);
@@ -1740,14 +1740,14 @@ fn test_atomicrmw() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let ptr_value = i32_type.ptr_type(AddressSpace::default()).get_undef();
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let ptr_value = context.ptr_type(AddressSpace::default()).get_undef();
     let zero_value = i32_type.const_zero();
@@ -1779,14 +1779,14 @@ fn test_atomicrmw() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let ptr_value = i31_type.ptr_type(AddressSpace::default()).get_undef();
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let ptr_value = context.ptr_type(AddressSpace::default()).get_undef();
     let zero_value = i31_type.const_zero();
@@ -1797,14 +1797,14 @@ fn test_atomicrmw() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let ptr_value = i4_type.ptr_type(AddressSpace::default()).get_undef();
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let ptr_value = context.ptr_type(AddressSpace::default()).get_undef();
     let zero_value = i4_type.const_zero();
@@ -1830,28 +1830,28 @@ fn test_cmpxchg() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let i32_ptr_type = context.ptr_type(AddressSpace::default());
     #[cfg(not(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let i32_ptr_ptr_type = i32_ptr_type.ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let i32_ptr_ptr_type = context.ptr_type(AddressSpace::default());
 
@@ -2029,14 +2029,14 @@ fn test_safe_struct_gep() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let i32_ptr_ty = i32_ty.ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let i32_ptr_ty = context.ptr_type(AddressSpace::default());
     let field_types = &[i32_ty.into(), i32_ty.into()];
@@ -2045,14 +2045,14 @@ fn test_safe_struct_gep() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let struct_ptr_ty = struct_ty.ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let struct_ptr_ty = context.ptr_type(AddressSpace::default());
     let fn_type = void_type.fn_type(&[i32_ptr_ty.into(), struct_ptr_ty.into()], false);
@@ -2088,7 +2088,7 @@ fn test_safe_struct_gep() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     {
         assert!(builder.build_struct_gep(i32_ty, i32_ptr, 0, "struct_gep").is_err());

--- a/tests/all/test_context.rs
+++ b/tests/all/test_context.rs
@@ -57,14 +57,14 @@ fn test_values_get_context() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let f32_ptr_type = context.ptr_type(AddressSpace::default());
     let f32_array_type = f32_type.array_type(2);

--- a/tests/all/test_debug_info.rs
+++ b/tests/all/test_debug_info.rs
@@ -33,7 +33,7 @@ fn test_smoke() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         "",
         #[cfg(any(
@@ -44,7 +44,7 @@ fn test_smoke() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         "",
     );
@@ -123,7 +123,7 @@ fn test_struct_with_placeholders() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         "",
         #[cfg(any(
@@ -134,7 +134,7 @@ fn test_struct_with_placeholders() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         "",
     );
@@ -255,7 +255,7 @@ fn test_no_explicit_finalize() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         "",
         #[cfg(any(
@@ -266,7 +266,7 @@ fn test_no_explicit_finalize() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         "",
     );
@@ -304,7 +304,7 @@ fn test_replacing_placeholder_with_placeholder() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         "",
         #[cfg(any(
@@ -315,7 +315,7 @@ fn test_replacing_placeholder_with_placeholder() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         "",
     );
@@ -367,7 +367,7 @@ fn test_anonymous_basic_type() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         "",
         #[cfg(any(
@@ -378,7 +378,7 @@ fn test_anonymous_basic_type() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         "",
     );
@@ -423,7 +423,7 @@ fn test_global_expressions() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         "",
         #[cfg(any(
@@ -434,7 +434,7 @@ fn test_global_expressions() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         "",
     );
@@ -497,7 +497,7 @@ fn test_pointer_types() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         "",
         #[cfg(any(
@@ -508,7 +508,7 @@ fn test_pointer_types() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         "",
     );
@@ -555,7 +555,7 @@ fn test_reference_types() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         "",
         #[cfg(any(
@@ -566,7 +566,7 @@ fn test_reference_types() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         "",
     );
@@ -614,7 +614,7 @@ fn test_array_type() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         "",
         #[cfg(any(
@@ -625,7 +625,7 @@ fn test_array_type() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         "",
     );

--- a/tests/all/test_execution_engine.rs
+++ b/tests/all/test_execution_engine.rs
@@ -58,7 +58,7 @@ fn test_jit_execution_engine() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let i8_ptr_ptr_type = context
         .i8_type()
@@ -68,7 +68,7 @@ fn test_jit_execution_engine() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let i8_ptr_ptr_type = context.ptr_type(AddressSpace::default());
     let one_i32 = i32_type.const_int(1, false);

--- a/tests/all/test_instruction_conversion.rs
+++ b/tests/all/test_instruction_conversion.rs
@@ -114,14 +114,14 @@ fn test_conversion_to_pointer_value() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let i64_ptr_type = context.i64_type().ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let i64_ptr_type = context.ptr_type(AddressSpace::default());
     let alloca_instr = builder

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -15,14 +15,14 @@ fn test_operands() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let f32_ptr_type = context.ptr_type(AddressSpace::default());
     let fn_type = void_type.fn_type(&[f32_ptr_type.into()], false);
@@ -271,14 +271,14 @@ fn test_instructions() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let f32_ptr_type = context.ptr_type(AddressSpace::default());
     let fn_type = void_type.fn_type(&[f32_ptr_type.into(), f32_type.into()], false);
@@ -375,14 +375,14 @@ fn test_volatile_atomicrmw_cmpxchg() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let i32_ptr_type = context.ptr_type(AddressSpace::default());
     let fn_type = void_type.fn_type(&[i32_ptr_type.into(), i32_type.into()], false);
@@ -442,14 +442,14 @@ fn test_mem_instructions() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let f32_ptr_type = context.ptr_type(AddressSpace::default());
     let fn_type = void_type.fn_type(&[f32_ptr_type.into(), f32_type.into()], false);
@@ -520,14 +520,14 @@ fn test_mem_instructions() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let f32_ptr_type = context.ptr_type(AddressSpace::default());
     let fn_type = void_type.fn_type(&[f32_ptr_type.into(), f32_type.into()], false);
@@ -564,7 +564,7 @@ fn test_mem_instructions() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let load = builder.build_load(f32_type, arg1, "").unwrap();
     let load_instruction = load.as_instruction_value().unwrap();
@@ -617,14 +617,14 @@ fn test_atomic_ordering_mem_instructions() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let f32_ptr_type = context.ptr_type(AddressSpace::default());
     let fn_type = void_type.fn_type(&[f32_ptr_type.into(), f32_type.into()], false);
@@ -661,7 +661,7 @@ fn test_atomic_ordering_mem_instructions() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let load = builder.build_load(f32_type, arg1, "").unwrap();
     let load_instruction = load.as_instruction_value().unwrap();
@@ -710,14 +710,14 @@ fn test_metadata_kinds() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let ptr_type = i8_type.ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let ptr_type = context.ptr_type(AddressSpace::default());
     let struct_type = context.struct_type(&[i8_type.into(), f32_type.into()], false);
@@ -757,14 +757,14 @@ fn test_find_instruction_with_name() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let i32_ptr_type = context.ptr_type(AddressSpace::default());
 
@@ -784,7 +784,7 @@ fn test_find_instruction_with_name() {
     assert_eq!(some_number.unwrap().get_name().unwrap().to_str(), Ok("some_number"))
 }
 
-#[llvm_versions(18..)]
+#[llvm_versions(18.1..)]
 #[test]
 fn test_fast_math_flags() {
     let context = Context::create();
@@ -828,7 +828,7 @@ fn test_fast_math_flags() {
     assert_eq!(f32_addition.get_fast_math_flags(), Some(1));
 }
 
-#[llvm_versions(18..)]
+#[llvm_versions(18.1..)]
 #[test]
 fn test_zext_non_negative_flag() {
     let context = Context::create();
@@ -870,7 +870,7 @@ fn test_zext_non_negative_flag() {
     assert_eq!(i32_sext.get_non_negative_flag(), None);
 }
 
-#[llvm_versions(18..)]
+#[llvm_versions(18.1..)]
 #[test]
 fn test_or_disjoint_flag() {
     let context = Context::create();

--- a/tests/all/test_targets.rs
+++ b/tests/all/test_targets.rs
@@ -428,7 +428,7 @@ fn test_write_target_machine_to_memory_buffer() {
     write_target_machine_to_memory_buffer(target_machine);
 }
 
-#[llvm_versions(18..)]
+#[llvm_versions(18.1..)]
 #[test]
 fn test_create_target_machine_from_default_options() {
     Target::initialize_x86(&InitializationConfig::default());
@@ -445,7 +445,7 @@ fn test_create_target_machine_from_default_options() {
     write_target_machine_to_memory_buffer(target_machine);
 }
 
-#[llvm_versions(18..)]
+#[llvm_versions(18.1..)]
 #[test]
 fn test_create_target_machine_from_options() {
     Target::initialize_x86(&InitializationConfig::default());

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -164,7 +164,7 @@ fn sized_types(global_ctx: &Context) {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let ptr_type = global_ctx.ptr_type(AddressSpace::default());
     let struct_type = global_ctx.struct_type(&[i8_type.into(), f128_type.into()], false);
@@ -195,7 +195,7 @@ fn sized_types(global_ctx: &Context) {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     assert!(ptr_type.is_sized());
     assert!(struct_type.is_sized());
@@ -211,7 +211,7 @@ fn sized_types(global_ctx: &Context) {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     {
         assert!(bool_type.ptr_type(AddressSpace::default()).is_sized());
@@ -248,7 +248,7 @@ fn sized_types(global_ctx: &Context) {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     assert!(ptr_type.array_type(42).is_sized());
     assert!(struct_type.array_type(0).is_sized());
@@ -272,7 +272,7 @@ fn sized_types(global_ctx: &Context) {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     assert!(ptr_type.vec_type(42).is_sized());
 
@@ -285,7 +285,7 @@ fn sized_types(global_ctx: &Context) {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     {
         let opaque_struct_ptr_type = opaque_struct_type.ptr_type(AddressSpace::default());
@@ -313,14 +313,14 @@ fn test_const_zero() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let ptr_type = f64_type.ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let ptr_type = context.ptr_type(AddressSpace::default());
     let vec_type = f64_type.vec_type(42);
@@ -405,7 +405,7 @@ fn test_const_zero() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )) {
         "ptr null"
     } else {
@@ -446,14 +446,14 @@ fn test_ptr_type() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let ptr_type = context.i8_type().ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let ptr_type = context.ptr_type(AddressSpace::default());
 
@@ -515,14 +515,14 @@ fn test_basic_type_enum() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         )))]
         &int.ptr_type(addr),
         #[cfg(any(
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         &context.ptr_type(addr),
         &context.struct_type(&[int.as_basic_type_enum()], false),
@@ -533,7 +533,7 @@ fn test_basic_type_enum() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         )))]
         assert_eq!(
             basic_type.as_basic_type_enum().ptr_type(addr),
@@ -565,14 +565,14 @@ fn test_ptr_address_space() {
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         )))]
         let ptr = context.i32_type().ptr_type(address_space);
         #[cfg(any(
             feature = "llvm15-0",
             feature = "llvm16-0",
             feature = "llvm17-0",
-            feature = "llvm18-0"
+            feature = "llvm18-1"
         ))]
         let ptr = context.ptr_type(address_space);
         assert_eq!(ptr.get_address_space(), address_space);

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -7,10 +7,10 @@ use inkwell::types::{AnyTypeEnum, StringRadix, VectorType};
 use inkwell::values::{AnyValue, InstructionOpcode::*, FIRST_CUSTOM_METADATA_KIND_ID};
 use inkwell::{AddressSpace, DLLStorageClass, GlobalVisibility, ThreadLocalMode};
 
-#[llvm_versions(18..)]
+#[llvm_versions(18.1..)]
 pub use llvm_sys::LLVMTailCallKind::*;
-#[cfg(feature = "llvm18-0")]
-use llvm_sys_180 as llvm_sys;
+#[cfg(feature = "llvm18-1")]
+use llvm_sys_181 as llvm_sys;
 
 use std::convert::TryFrom;
 
@@ -70,7 +70,7 @@ fn test_call_site() {
 }
 
 #[test]
-#[cfg(feature = "llvm18-0")]
+#[cfg(feature = "llvm18-1")]
 fn test_call_site_tail_call_attributes() {
     let context = Context::create();
     let builder = context.create_builder();
@@ -115,7 +115,7 @@ fn test_set_get_name() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let ptr_type = context.ptr_type(AddressSpace::default());
     let array_type = f64_type.array_type(42);
@@ -135,14 +135,14 @@ fn test_set_get_name() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let ptr_val = bool_type.ptr_type(AddressSpace::default()).const_null();
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let ptr_val = ptr_type.const_null();
     let array_val = f64_type.const_array(&[f64_val]);
@@ -204,14 +204,14 @@ fn test_set_get_name() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let ptr_type = bool_type.ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let ptr_type = context.ptr_type(AddressSpace::default());
     let struct_type = context.struct_type(&[bool_type.into()], false);
@@ -288,7 +288,7 @@ fn test_undef() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let ptr_type = context.ptr_type(AddressSpace::default());
     let array_type = f64_type.array_type(42);
@@ -310,14 +310,14 @@ fn test_undef() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let ptr_val = bool_type.ptr_type(AddressSpace::default()).const_null();
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let ptr_val = ptr_type.const_null();
     let array_val = f64_type.const_array(&[f64_val]);
@@ -355,14 +355,14 @@ fn test_undef() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let ptr_undef = bool_type.ptr_type(AddressSpace::default()).get_undef();
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let ptr_undef = ptr_type.get_undef();
     let array_undef = array_type.get_undef();
@@ -405,7 +405,7 @@ fn test_poison() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let ptr_type = context.ptr_type(AddressSpace::default());
     let array_type = f64_type.array_type(42);
@@ -427,14 +427,14 @@ fn test_poison() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let ptr_val = bool_type.ptr_type(AddressSpace::default()).const_null();
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let ptr_val = ptr_type.const_null();
     let array_val = f64_type.const_array(&[f64_val]);
@@ -472,14 +472,14 @@ fn test_poison() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let ptr_poison = bool_type.ptr_type(AddressSpace::default()).get_poison();
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let ptr_poison = ptr_type.get_poison();
     let array_poison = array_type.get_poison();
@@ -624,7 +624,7 @@ fn test_metadata() {
         let f32_type = context.f32_type();
         // let f64_type = context.f64_type();
         // let f128_type = context.f128_type();
-        // #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+        // #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
         // let ptr_type = context.ptr_type(AddressSpace::default());
         // let array_type = f64_type.array_type(42);
         // let ppc_f128_type = context.ppc_f128_type();
@@ -641,9 +641,9 @@ fn test_metadata() {
         // let f64_val = f64_type.const_float(0.0);
         // let f128_val = f128_type.const_float(0.0);
         // let ppc_f128_val = ppc_f128_type.const_float(0.0);
-        // #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+        // #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
         // let ptr_val = bool_type.ptr_type(AddressSpace::default()).const_null();
-        // #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+        // #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
         // let ptr_val = ptr_type.const_null();
         // let array_val = f64_type.const_array(&[f64_val]);
         // let struct_val = context.const_struct(&[i8_val.into(), f128_val.into()], false);
@@ -747,7 +747,7 @@ fn test_metadata() {
 
 #[test]
 fn test_floats() {
-    #[cfg(not(any(feature = "llvm15-0", feature = "llvm18-0")))]
+    #[cfg(not(any(feature = "llvm15-0", feature = "llvm18-1")))]
     {
         use inkwell::FloatPredicate;
 
@@ -782,7 +782,7 @@ fn test_floats() {
 
         let f64_one = f64_type.const_float(1.);
         let f64_two = f64_type.const_float(2.);
-        #[cfg(not(any(feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+        #[cfg(not(any(feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1")))]
         {
             let neg_two = f64_two.const_neg();
 
@@ -1167,7 +1167,7 @@ fn test_allocations() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )) {
         "ptr"
     } else {
@@ -1438,14 +1438,14 @@ fn test_non_fn_ptr_called() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let i8_ptr_type = i8_type.ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let i8_ptr_type = context.ptr_type(AddressSpace::default());
     let fn_type = i8_type.fn_type(&[i8_ptr_type.into()], false);
@@ -1476,7 +1476,7 @@ fn test_non_fn_ptr_called() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     builder
         .build_indirect_call(i8_ptr_type.fn_type(&[], false), i8_ptr_param, &[], "call")
@@ -1524,14 +1524,14 @@ fn test_aggregate_returns() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     )))]
     let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     let i32_ptr_type = context.ptr_type(AddressSpace::default());
     let i32_three = i32_type.const_int(3, false);
@@ -1562,7 +1562,7 @@ fn test_aggregate_returns() {
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
-        feature = "llvm18-0"
+        feature = "llvm18-1"
     ))]
     builder
         .build_ptr_diff(i32_ptr_type, ptr_param1, ptr_param2, "diff")


### PR DESCRIPTION
This is needed in order to upgrade the compiler to LLVM 18.1. 

Q: Why can't we use LLVM 18?

A: Because the GitHub Actions LLVM installer package https://github.com/KyleMayes/install-llvm-action doesn't have any LLVM 18.0.X variants available. We could instead perhaps provide a LLVM 18 distro ourselves (but this seems tedious to do rather than to temporarily enable 18.1 support in inkwell).